### PR TITLE
ratings take into account number of users

### DIFF
--- a/app/models/package_rating.rb
+++ b/app/models/package_rating.rb
@@ -42,6 +42,11 @@ class PackageRating < ActiveRecord::Base
                                    package_id]).to_f
     end
   end
+  
+  #Package ratings should take into account number of users and their ratings
+  def self.calculate_rating(package_id, aspect=nil)
+      self.sum(sqrt('rating'*count('users'))).to_f
+  end
 
   def to_s
     rating.to_s


### PR DESCRIPTION
Take a look at http://crantastic.org/popcon, the top 5 packages I have never heard of:
- fields, analogue, klaR, neuralnet, GGally

They have 2-3 users apiece who have rated it 5.0/5 stars.

---

The "most popular" should be computed taking both number of users and ratings into account. I propose multiplying them together.

Perhaps it would be appropriate to `sqrt` the product and/or `exp` the ratings.
