### PR TITLE
improve the ordering of packages

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -63,7 +63,7 @@ class Package < ActiveRecord::Base
                        :conditions => "#{self.table_name}.created_at IS NOT NULL",
                        :limit => 50
 
-  named_scope :most_popular, :order => "score DESC, package_users_count DESC",
+  named_scope :most_popular, :order => "score DESC * package_users_count DESC",
                              :include => :latest_version,
                              :limit => 5
 


### PR DESCRIPTION
Packages are currently being sorted wrong. Packages with few users are showing up at the top because the average rating by a small number of users gets first priority.

It would make more sense to sort by the _total_ number of stars rather than the average number, because this will reflect both  number of users and how much they like the package in question.

More complex sorting schemes (e.g., penalising extra for any instances of one-star) might also make sense.
